### PR TITLE
Adding functionality to enable editing the unit of measure. #523

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "NODE_OPTIONS=--max_old_space_size=8192 ng serve",
-    "build": "NODE_OPTIONS=--max_old_space_size=8192 ng build",
+    "start": "set NODE_OPTIONS=--max_old_space_size=8192 && ng serve",
+    "build": "set NODE_OPTIONS=--max_old_space_size=8192 && ng build",
     "build:prod": "ng build --aot --configuration production",
     "test": "ng test",
     "test:headless": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",

--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -98,7 +98,7 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
       });
   }
 
-  // fixed error on edit-unit-of-measure//
+  // fixed error on edit-unit-of-measure
   onEdit(event: Event, drug): void {
     this.dialog
     .open(ManageUnitOfMeasureModalComponent, {

--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -97,9 +97,8 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
         }
       });
   }
-  //Errors were found in this part. where we found the "onEdit" function 
+  //Errors were found in this part. where we found the "onEdit" function
   // which was empty and could not allow user to make editing.
-  
   // fixed error on edit-unit-of-measure
   onEdit(event: Event, drug): void {
     this.dialog

--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -98,5 +98,21 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
       });
   }
 
-  onEdit(concept: ConceptGet): void {}
+  // fixed error on edit-unit-of-measure//
+  onEdit(event: Event, drug): void {
+    this.dialog
+    .open(ManageUnitOfMeasureModalComponent, {
+      minWidth: "40%",
+      data: {
+       
+      },
+    })
+    .afterClosed()
+    .subscribe((shouldReloadData) => {
+      if (shouldReloadData) {
+        this.getUnitsOfMeasure();
+      }
+       });
+    }
+//end of fixed bug
 }

--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -97,7 +97,9 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
         }
       });
   }
-
+  //Errors were found in this part. where we found the "onEdit" function 
+  // which was empty and could not allow user to make editing.
+  
   // fixed error on edit-unit-of-measure
   onEdit(event: Event, drug): void {
     this.dialog


### PR DESCRIPTION
Bug that has to be fixed: **Unit of Measure Dialog Data Issue**

**Issue Description and Summary**:
The edit functionality for Unit of Measure was failing because the dialog component wasn't receiving the necessary data object when opened for the user to edit them.
After fixing a bug, editing was enabled and tested. 

**Root Cause**:
The data object in the configuration was empty, preventing the editing component from accessing the current unit of measure details.

**Solution:**
We were able to modify the "onEdit" method to properly pass the drug data to the dialog component.

**Participants**:

Name: TAMAKILILO, Eliud Elia
Reg no. 2021-04-12129

Name: Mao, Raymond Paul
Reg no. 2022-04-06174

Name: Mponda, Glory Baraka
Reg no. 2022-04-08330

Name: Rwegasira, Theresia P
Reg no. 2022-04-11562



Pull request link: "https://github.com/dhis2-club-tanzania/icare-student/pull/18#issue-2793635930"
push url: "https://github.com/MrTamakililo/icare-student.git"

