### PR TITLE
Adding functionality to enable editing the unit of measure. #523 

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "NODE_OPTIONS=--max_old_space_size=8192 ng serve",
-    "build": "NODE_OPTIONS=--max_old_space_size=8192 ng build",
+    "start": "set NODE_OPTIONS=--max_old_space_size=8192 && ng serve",
+    "build": "set NODE_OPTIONS=--max_old_space_size=8192 && ng build",
     "build:prod": "ng build --aot --configuration production",
     "test": "ng test",
     "test:headless": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",

--- a/ui/src/app/shared/components/pricing-item/pricing-item.component.ts
+++ b/ui/src/app/shared/components/pricing-item/pricing-item.component.ts
@@ -79,8 +79,10 @@ export class PricingItemComponent implements OnInit {
   }
 
   onSaveItemPrice(e) {
+    e.preventDefault(); 
     e.stopPropagation();
     this.showForm = false;
+
     this.saveItemPrice.emit({
       item: {
         uuid: this.pricingItem?.uuid,

--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -97,6 +97,19 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
         }
       });
   }
-
-  onEdit(concept: ConceptGet): void {}
+   onEdit(event: Event, drug): void {
+      this.dialog
+        .open(ManageUnitOfMeasureModalComponent, {
+          minWidth: "40%",
+          data: {
+           
+          },
+        })
+        .afterClosed()
+        .subscribe((shouldReloadData) => {
+          if (shouldReloadData) {
+            this.getUnitsOfMeasure();
+          }
+        });
+    }
 }

--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -97,7 +97,8 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
         }
       });
   }
-   onEdit(event: Event, drug): void {
+  // this is where we fix an error. 
+  onEdit(event: Event, drug): void {
       this.dialog
         .open(ManageUnitOfMeasureModalComponent, {
           minWidth: "40%",


### PR DESCRIPTION
Bug that has to be fixed: Unit of Measure Dialog Data Issue

Issue Description and Summary:
Issue #523, Bug description: user fails to open edit modal when edit option is clicked.

Solution:
Modified the "onEdit" method to properly pass dataand open modal when clicked.

Participants:

Name: Mponda, Glory Baraka
Reg no. 2022-04-08330

Name: TAMAKILILO, Eliud Elia
Reg no. 2021-04-12129

Name: Mao, Raymond Paul
Reg no. 2022-04-06174

Name: Rwegasira, Theresia P
Reg no. 2022-04-11562