### PR TITLE
Fix for Prescription Refill Restriction Bug (Feature/Restrict-Prescription-Refill-158)

### DIFF
--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { getGenericDrugPrescriptionsFromVisit } from "../../helpers/visits.helper";
 import { uniqBy, keyBy } from "lodash";
 import { Observable } from "rxjs";
 import { FormValue } from "src/app/shared/modules/form/models/form-value.model";
@@ -201,6 +202,23 @@ export class GeneralDispensingFormComponent implements OnInit {
   }
 
   saveOrder(e: any, conceptFields: any) {
+    
+    const prescriptions = getGenericDrugPrescriptionsFromVisit(this.currentVisit, this.orderType);
+        let drug_names: string[] = [];;
+
+    // Accessing the values
+    prescriptions.forEach(item => {
+      if (this.specificDrugConceptUuid in item.obs){
+        drug_names.push(item.obs[this.specificDrugConceptUuid].comment);
+        console.log(item.obs[this.specificDrugConceptUuid]);
+        
+      }
+    });
+    prescriptions.forEach(item => {
+      if(item.obs[this.specificDrugConceptUuid].comment === this.formValues?.drug?.value.drug.display) {
+        drug_obs = item.obs
+      }
+    })
     if (!this.formValues?.drug?.value) {
       this.errors = [];
       setTimeout(() => {

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -244,7 +244,23 @@ export class GeneralDispensingFormComponent implements OnInit {
           },
         ];
       });
-    } else {
+    } 
+    
+ if(drug_obs &&
+      drug_obs[this.specificDrugConceptUuid].comment === this.formValues?.drug?.value.drug.display
+    ) {
+      const duration = parseInt(drug_obs[this.generalPrescriptionDurationConcept].display.split(': ')[1], 10)
+      const unit = drug_obs[this.durationUnitsSettings].display.split(': ')[1].toLowerCase()
+      const now = new Date();
+      const obs_datetime = drug_obs[this.specificDrugConceptUuid].obsDatetime.replace(/(\+|-)(\d{2})(\d{2})$/, '$1$2:$3')
+      // console.log(drug_obs);
+      
+      // console.log(parseInt(drug_obs[this.generalPrescriptionDurationConcept].display.split(': ')[1], 10));
+      // console.log(drug_obs[this.durationUnitsSettings].display.split(': ')[1].toLowerCase());
+      // console.log(parseISO(obs_datetime))
+      // console.log(now);
+
+    else {
       this.savingOrder = true;
       let encounterObject = {
         patient: this.currentPatient?.id,

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { getGenericDrugPrescriptionsFromVisit } from "../../helpers/visits.helper";
 import { uniqBy, keyBy } from "lodash";
+import { add, parseISO } from 'date-fns';
 import { Observable } from "rxjs";
 import { FormValue } from "src/app/shared/modules/form/models/form-value.model";
 import {
@@ -204,21 +205,6 @@ export class GeneralDispensingFormComponent implements OnInit {
   saveOrder(e: any, conceptFields: any) {
     
     const prescriptions = getGenericDrugPrescriptionsFromVisit(this.currentVisit, this.orderType);
-        let drug_names: string[] = [];;
-
-    // Accessing the values
-    prescriptions.forEach(item => {
-      if (this.specificDrugConceptUuid in item.obs){
-        drug_names.push(item.obs[this.specificDrugConceptUuid].comment);
-        console.log(item.obs[this.specificDrugConceptUuid]);
-        
-      }
-    });
-    // prescriptions.forEach(item => {
-      //   if(item.obs[this.specificDrugConceptUuid].comment === this.formValues?.drug?.value.drug.display) {
-      //     drug_obs = item.obs
-      //   }
-      // })
     let drug_obs;
     for (const item of prescriptions) {
       if (item.obs[this.specificDrugConceptUuid]?.comment === this.formValues?.drug?.value.drug.display) {
@@ -226,11 +212,7 @@ export class GeneralDispensingFormComponent implements OnInit {
         break; // Exit the loop once the condition is met
       }
     }
-    prescriptions.forEach(item => {
-      if(item.obs[this.specificDrugConceptUuid].comment === this.formValues?.drug?.value.drug.display) {
-        drug_obs = item.obs
-      }
-    })
+    
     if (!this.formValues?.drug?.value) {
       this.errors = [];
       setTimeout(() => {
@@ -253,13 +235,18 @@ export class GeneralDispensingFormComponent implements OnInit {
       const unit = drug_obs[this.durationUnitsSettings].display.split(': ')[1].toLowerCase()
       const now = new Date();
       const obs_datetime = drug_obs[this.specificDrugConceptUuid].obsDatetime.replace(/(\+|-)(\d{2})(\d{2})$/, '$1$2:$3')
-      // console.log(drug_obs);
-      
-      // console.log(parseInt(drug_obs[this.generalPrescriptionDurationConcept].display.split(': ')[1], 10));
-      // console.log(drug_obs[this.durationUnitsSettings].display.split(': ')[1].toLowerCase());
-      // console.log(parseISO(obs_datetime))
-      // console.log(now);
-
+    // Define the mapping of units to date-fns duration objects
+      const unitMap: { [key: string]: any } = {
+        minutes: { minutes: duration },
+        hours: { hours: duration },
+        days: { days: duration },
+        weeks: { weeks: duration }, 
+        months: { months: duration },
+        years: { years: duration },
+      };
+      //calculate end date
+      const result_time = add(parseISO(obs_datetime), unitMap[unit]);
+ }
     else {
       this.savingOrder = true;
       let encounterObject = {

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -214,6 +214,18 @@ export class GeneralDispensingFormComponent implements OnInit {
         
       }
     });
+    // prescriptions.forEach(item => {
+      //   if(item.obs[this.specificDrugConceptUuid].comment === this.formValues?.drug?.value.drug.display) {
+      //     drug_obs = item.obs
+      //   }
+      // })
+    let drug_obs;
+    for (const item of prescriptions) {
+      if (item.obs[this.specificDrugConceptUuid]?.comment === this.formValues?.drug?.value.drug.display) {
+        drug_obs = item.obs;
+        break; // Exit the loop once the condition is met
+      }
+    }
     prescriptions.forEach(item => {
       if(item.obs[this.specificDrugConceptUuid].comment === this.formValues?.drug?.value.drug.display) {
         drug_obs = item.obs

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -246,8 +246,21 @@ export class GeneralDispensingFormComponent implements OnInit {
       };
       //calculate end date
       const result_time = add(parseISO(obs_datetime), unitMap[unit]);
+      if (now < result_time) {
+      console.log('tumezuia kurudia dawa mda haujaisha');
+      setTimeout(() => {
+        this.errors = [
+          ...this.errors,
+          {
+            error: {
+              message: "The selected drug is already in the current prescription!",
+            },
+          },
+        ];
+      });
+      return; // Exit early if the condition is met
+     }
  }
-    else {
       this.savingOrder = true;
       let encounterObject = {
         patient: this.currentPatient?.id,
@@ -370,5 +383,4 @@ export class GeneralDispensingFormComponent implements OnInit {
 
       this.updateConsultationOrder.emit();
     }
-  }
 }


### PR DESCRIPTION
Issue
Practitioners were able to refill prescriptions before the end time of the current prescription, due to improper handling of prescription duration and time units.

Cause:
- lack comparison logic for prescription duration.

Solution:
- Implemented proper validation to check if the drug is already in the current prescription.
- Parsed and compared the observation date using date-fns library to know the end date of the current prescription and the drug being prescribed.
- Added user-friendly error messages to prevent premature refills.

Participants:
Nuh Saidi Buhero: 2022-04-00886
Hud Saidi Buhero 2022-04-00887
RWEGASILA KELVIN BYABATO: 2022-04-00982
FRENK OGWEYO ELIJA: 2021-04-01667
NURDIN RULLO: 2022-04-11520