### PR TITLE
Feature/doseunitautoselector

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "NODE_OPTIONS=--max_old_space_size=8192 ng serve",
-    "build": "NODE_OPTIONS=--max_old_space_size=8192 ng build",
+    "start": "set NODE_OPTIONS=--max_old_space_size=8192 && ng serve",
+    "build": "set NODE_OPTIONS=--max_old_space_size=8192 && ng build",
     "build:prod": "ng build --aot --configuration production",
     "test": "ng test",
     "test:headless": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",

--- a/ui/src/app/shared/components/unit-field/unit-field.component.ts
+++ b/ui/src/app/shared/components/unit-field/unit-field.component.ts
@@ -11,18 +11,19 @@ export class UnitFieldComponent implements OnInit {
   @Input() durationUnits: any;
   @Input() drugRoutes: any;
   @Input() dosingFrequencies: any;
-
+  @Input() selectedValue: any;
   @Output() formUpdate = new EventEmitter();
   unitField: Dropdown;
 
   constructor() {}
 
   ngOnInit(): void {
+    console.log( this.selectedValue);
     if (this.dosingUnits) {
       this.unitField = new Dropdown({
         id: "dosingUnit",
         key: "dosingUnit",
-        label: `Dose Unit`,
+        label:  this.selectedValue? this.selectedValue:`Dose Unit`,
         conceptClass: this.dosingUnits?.conceptClass?.display,
         value: null,
         required: true,

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.html
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.html
@@ -20,9 +20,7 @@
     <div>
       <app-form
         [fields]="[drugConceptField]"
-        (formUpdate)="
-          onFormUpdate($event, 'drug', params?.keyedPreviousVisitDrugOrders)
-        "
+        (formUpdate)="onFormUpdate($event, 'drug', params?.keyedPreviousVisitDrugOrders)"
       ></app-form>
     </div>
     <div class="row" *ngIf="params?.conceptFields">
@@ -39,11 +37,16 @@
         ></app-form>
       </div>
       <div class="col-4" *ngIf="dosingUnits$ | async as dosingUnits">
+        <div *ngIf="selectedDosingUnit">
+          {{ selectedDosingUnit}} is selected
+        </div>
         <app-unit-field
           [dosingUnits]="dosingUnits"
+          [selectedValue]="selectedDosingUnit"
           (formUpdate)="onFormUpdate($event)"
         ></app-unit-field>
       </div>
+      
       <div
         class="col-4"
         *ngIf="dosingFrequencies$ | async as dosingFrequencies"
@@ -113,6 +116,7 @@
         <span>{{ savingOrder ? "Saving..." : "Save" }}</span>
       </button>
     </div>
-    <!-- {{ selectedDrug | json }} -->
+    
+    <!-- <pre>{{ selectedDrug | json }}</pre> -->
   </div>
 </div>

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -169,7 +169,7 @@ export class GeneralDispensingFormComponent implements OnInit {
       (formValues.getValues()?.drug?.value as any)?.display
     ) {
       this.selectedDrug = formValues.getValues()?.drug?.value;
-      console.log("Selected drug:", this.selectedDrug);
+      // console.log("Selected drug:", this.selectedDrug);
       // Check if drug name contains units
       const drugName = this.selectedDrug?.display || "";
       // console.log("Drug name:", drugName);

--- a/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
+++ b/ui/src/app/shared/dialogs/general-dispension-form/general-dispension-form.component.ts
@@ -78,7 +78,7 @@ export class GeneralDispensingFormComponent implements OnInit {
   errors: any[] = [];
   selectedDrug: any;
   keyedPreviousVisitDrugOrders$: Observable<any>;
-
+  selectedDosingUnit: any; 
   constructor(
     private ordersService: OrdersService,
     private observationService: ObservationService,
@@ -149,12 +149,13 @@ export class GeneralDispensingFormComponent implements OnInit {
   ): void {
     this.selectedDrug = null;
     this.isFormValid = formValues.isValid;
-
+  
     this.formValues = { ...this.formValues, ...formValues.getValues() };
-
+  
     const doseDataValueKey: any = (Object.keys(this.formValues)?.filter(
       (key) => this.formValues[key]?.label === "Dose"
     ) || [])[0];
+  
     this.isFormValid =
       this.isFormValid &&
       this.formValues[doseDataValueKey]?.value?.length > 0 &&
@@ -162,12 +163,55 @@ export class GeneralDispensingFormComponent implements OnInit {
       this.formValues?.frequency?.value?.length > 0
         ? true
         : false;
+  
     if (
       formValues.getValues()?.drug?.value?.length > 0 ||
       (formValues.getValues()?.drug?.value as any)?.display
     ) {
       this.selectedDrug = formValues.getValues()?.drug?.value;
+      console.log("Selected drug:", this.selectedDrug);
+      // Check if drug name contains units
+      const drugName = this.selectedDrug?.display || "";
+      // console.log("Drug name:", drugName);
+  
+      // Subscribe to dosing units observable and process the result
+      this.dosingUnits$.subscribe((dosingUnitsResponse) => {
+        // Extract the array of dosing units from `answers` or `setMembers`
+        const dosingUnits = dosingUnitsResponse?.answers || dosingUnitsResponse?.setMembers || [];
+        // console.log("Available dosing units:", dosingUnits);
+  
+        // Find all matching units in the drug name
+        const matchingUnits = dosingUnits.filter((unit: any) =>
+          drugName.toLowerCase().includes(unit.display.toLowerCase())
+        );
+  
+        if (matchingUnits.length > 0) {
+          // Define a prioritization order for units
+          const prioritizationOrder = ["tablet", "capsule", "mg", "ml"];
+  
+          // Sort matching units by prioritization order
+          const prioritizedUnit =
+            matchingUnits.sort((a, b) => {
+              const indexA = prioritizationOrder.indexOf(a.display);
+              const indexB = prioritizationOrder.indexOf(b.display);
+              return (
+                (indexA === -1 ? Infinity : indexA) -
+                (indexB === -1 ? Infinity : indexB)
+              );
+            })[0];
+  
+          // Automatically set the dosing unit to the best match
+          this.formValues["dosingUnit"] = {
+            value: prioritizedUnit.uuid,
+            label: prioritizedUnit.display,
+          };
+          this.selectedDosingUnit = prioritizedUnit.display;
+          console.log("Selected dosing unit:", this.selectedDosingUnit);
+          
+        }
+      });
     }
+  
     if (fieldItem == "drug" && !this.specificDrugConceptUuid) {
       this.drugService
         .getDrugsUsingConceptUuid(this.formValues?.drug?.value)
@@ -199,6 +243,7 @@ export class GeneralDispensingFormComponent implements OnInit {
         });
     }
   }
+  
 
   saveOrder(e: any, conceptFields: any) {
     if (!this.formValues?.drug?.value) {


### PR DESCRIPTION
Members 
Dereck George Tano 2022-04-12872 
Ashiraf B Issa 2022-04-02746
Megan Bwire 2022-04-00977
Yasinter Sylvester mayalla  2022-04-06747
Irene Donatus Gadiye 2022-04-01997

Key Changes:
Dosing Unit Selection Logic:

When a drug is selected, the drug name is analyzed to determine the appropriate dosing unit (e.g., "mg", "Capsules", "tablets", "ml").

The dosing unit is prioritized based on a predefined order: ["mg", "Capsules", "tablets", "ml"].

The selected dosing unit is then passed to the unit-field component to update the dropdown.

Integration with unit-field Component:

The unit-field component now accepts a selectedValue input, which is used to set the initial value of the dropdown.

The dropdown is populated with the available dosing units, and the selected unit is highlighted based on the drug name.

Form Updates:

The formValues object is updated to include the selected dosing unit, ensuring that the form reflects the correct unit when the drug is selected.

How Dosing Units are Pulled:
The dosing units are fetched from the dosingUnits$ observable, which provides a list of available units (e.g., answers or setMembers from the API response).

The drug name is matched against the available dosing units to determine the most appropriate unit.