### PR TITLE
Feat/add tab for stopped medication

### DIFF
--- a/omods/core/api/src/main/resources/liquibase.xml
+++ b/omods/core/api/src/main/resources/liquibase.xml
@@ -5074,6 +5074,29 @@
             </column>
         </addColumn>
     </changeSet>
+
+    
+    <!-- STOPPED MEDICATION TABLE -->
+    <changeSet id="create_stopped_medication" author="moody-amin" dbms="mysql">
+    <preConditions onFail="MARK_RAN">
+        <not>
+            <tableExists tableName="stopped_medication"/>
+        </not>
+    </preConditions>
+    <comment>Creating openmrs stopped_medication table</comment>
+    <createTable tableName="stopped_medication">
+    <column name="id" type="INTEGER" autoIncrement="true">
+        <constraints primaryKey="true" primaryKeyName="stopped_medication_id_pk"/>
+    </column>
+    <column name="patient_id" type="INTEGER">
+        <constraints nullable="false"></constraints>
+    </column>
+    <column name="prescription" type="TEXT"/>
+    <column name="remarks" type="TEXT"/>
+    </createTable>
+    </changeSet>
+
+
     <changeSet id="add_status_to_bl_payment_item_table" author="gaspar-giddson" dbms="mysql">
         <preConditions onFail="MARK_RAN">
             <not>

--- a/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
+++ b/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
@@ -245,31 +245,24 @@
           <ng-template matTabContent>
             <div>
               <table class="w-100 table table-bordered">
+                <thead>
+                  <tr>
+                    <th>S/N</th>
+                    <th>Prescription</th>
+                    <th>Remarks</th>
+                  </tr>
+                </thead>
                 <tbody>
-                  <tr class="p-4">
-                    <app-current-prescriptions
-                      *ngIf="
-                        drugParams?.currentVisit &&
-                        drugParams?.generalPrescriptionOrderType
-                      "
-                      [visit]="drugParams?.currentVisit"
-                      [genericPrescriptionOrderType]="
-                        drugParams?.generalPrescriptionOrderType
-                      "
-                      [fromClinic]="forConsultation"
-                      (loadVisit)="loadVisit($event)"
-                    ></app-current-prescriptions>
-                    <mat-progress-bar
-                      *ngIf="
-                        !drugParams?.currentVisit ||
-                        !drugParams?.generalPrescriptionOrderType
-                      "
-                      mode="indeterminate"
-                    >
-                    </mat-progress-bar>
+                  <tr *ngFor="let prescription of prescriptions; let i = index">
+                    <td>{{ i + 1 }}</td>
+                    <td>{{ prescription.name }}</td>
+                    <td>{{ prescription.remarks }}</td>
                   </tr>
                 </tbody>
               </table>
+              <div *ngIf="prescriptions.length === 0">
+                No stopped medications available.
+              </div>
             </div>
           </ng-template>
         </div>

--- a/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
+++ b/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
@@ -237,6 +237,18 @@
           </ng-template>
         </div>
       </mat-tab>
+      <mat-tab
+        label="Stopped Medication"
+        *ngIf="!previous"
+      >
+        <div class="mat-tab-container">
+          <ng-template matTabContent>
+            <div>
+              Hello World!!!
+            </div>
+          </ng-template>
+        </div>
+      </mat-tab>
       <mat-tab label="Drugs" *ngIf="previous">
         <div class="mat-tab-container">
           <ng-template matTabContent>

--- a/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
+++ b/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
@@ -244,7 +244,32 @@
         <div class="mat-tab-container">
           <ng-template matTabContent>
             <div>
-              Hello World!!!
+              <table class="w-100 table table-bordered">
+                <tbody>
+                  <tr class="p-4">
+                    <app-current-prescriptions
+                      *ngIf="
+                        drugParams?.currentVisit &&
+                        drugParams?.generalPrescriptionOrderType
+                      "
+                      [visit]="drugParams?.currentVisit"
+                      [genericPrescriptionOrderType]="
+                        drugParams?.generalPrescriptionOrderType
+                      "
+                      [fromClinic]="forConsultation"
+                      (loadVisit)="loadVisit($event)"
+                    ></app-current-prescriptions>
+                    <mat-progress-bar
+                      *ngIf="
+                        !drugParams?.currentVisit ||
+                        !drugParams?.generalPrescriptionOrderType
+                      "
+                      mode="indeterminate"
+                    >
+                    </mat-progress-bar>
+                  </tr>
+                </tbody>
+              </table>
             </div>
           </ng-template>
         </div>

--- a/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.ts
+++ b/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.ts
@@ -30,6 +30,12 @@ export class PatientMedicationSummaryComponent implements OnInit {
   useGeneralPrescription$: Observable<any>;
   currentVisit$: Observable<any>;
 
+  prescriptions = [
+    { id: 1, name: 'Diclofenac+Paracetamol+Chlorzoxazone Tablets 50mg+325mg+250mg - 1 (capsule) qid / 6 hrly 6 Days Oral', remarks: 'Skin reaction with the medication' },
+    { id: 2, name: 'Paracetamol 500mg Tablet(s) - 1 (tablet) immediately / stat 2 Days Oral', remarks: 'Addiction to medication' },
+    { id: 3, name: 'Chlorzoxazone + Diclofenac + Paracetamol Tablet: 250mg+50mg+325mg - 1 (capsule) od 1 Weeks Topical', remarks: 'Testing the remarks!!!!' }
+  ];
+
   @Output() updateConsultationOrder = new EventEmitter();
   @Output() updateMedicationComponent = new EventEmitter();
   patientDrugOrdersStatuses$: Observable<any>;


### PR DESCRIPTION
Stopped Medication Tab
We’ve introduced a new feature in the system. The stopped medication tab provides a comprehensive list of medications that have been discontinued for patients. It includes detailed information, such as:

1. The names of the stopped medications.
2. Associated remarks explaining the reasons for discontinuation.

2022-04-13814
2022-04-13819
2022-04-13806
2022-04-13804
2022-04-01007