### PR TITLE
Preventing prescription of the same dose when there's an existing one.

### DIFF
--- a/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
+++ b/ui/src/app/shared/components/patient-medication-summary/patient-medication-summary.component.html
@@ -7,142 +7,86 @@
     drugOrders: drugOrders$ | async
   } as drugParams"
 >
+  <!-- Progress Bar -->
   <mat-progress-bar
     mode="indeterminate"
     *ngIf="!drugParams?.useGeneralPrescription || !drugParams?.currentVisit"
   ></mat-progress-bar>
+
+  <!-- Main Content -->
   <div *ngIf="drugParams?.useGeneralPrescription && drugParams?.currentVisit">
     <mat-tab-group *ngIf="drugParams?.currentVisit?.hasConfirmedDiagnosis">
+
+      <!-- Doctor's Prescriptions Tab -->
       <mat-tab
         label="Doctor's Prescriptions"
-        *ngIf="
-          drugParams?.useGeneralPrescription === 'true' &&
-          !previous &&
-          !forHistory
-        "
+        *ngIf="drugParams?.useGeneralPrescription === 'true' && !previous && !forHistory"
       >
         <div class="mat-tab-container">
           <ng-template matTabContent>
-            <div>
-              <table class="w-100 table table-bordered">
-                <tbody>
-                  <tr class="p-4">
-                    <app-current-prescriptions
-                      *ngIf="
-                        drugParams?.currentVisit &&
-                        drugParams?.generalPrescriptionOrderType
-                      "
-                      [visit]="drugParams?.currentVisit"
-                      [genericPrescriptionOrderType]="
-                        drugParams?.generalPrescriptionOrderType
-                      "
-                      [fromClinic]="forConsultation"
-                      (loadVisit)="loadVisit($event)"
-                    ></app-current-prescriptions>
-                    <mat-progress-bar
-                      *ngIf="
-                        !drugParams?.currentVisit ||
-                        !drugParams?.generalPrescriptionOrderType
-                      "
-                      mode="indeterminate"
+            <table class="w-100 table table-bordered">
+              <tbody>
+                <tr class="p-4">
+                  <app-current-prescriptions
+                    *ngIf="drugParams?.currentVisit && drugParams?.generalPrescriptionOrderType"
+                    [visit]="drugParams?.currentVisit"
+                    [genericPrescriptionOrderType]="drugParams?.generalPrescriptionOrderType"
+                    [fromClinic]="forConsultation"
+                    (loadVisit)="loadVisit($event)"
+                  ></app-current-prescriptions>
+                  <mat-progress-bar
+                    *ngIf="!drugParams?.currentVisit || !drugParams?.generalPrescriptionOrderType"
+                    mode="indeterminate"
+                  ></mat-progress-bar>
+                </tr>
+                <tr *ngIf="!isInpatient">
+                  <td colspan="3">
+                    <button
+                      mat-flat-button
+                      class="float-right"
+                      color="primary"
+                      (click)="onAddOrder($event)"
                     >
-                    </mat-progress-bar>
-                  </tr>
-                  <tr *ngIf="!isInpatient">
-                    <td colspan="3">
-                      <button
-                        mat-flat-button
-                        class="float-right"
-                        color="primary"
-                        (click)="onAddOrder($event)"
-                      >
-                        <mat-icon>add</mat-icon>
-                        <span class="ml-2">Add Prescription</span>
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+                      <mat-icon>add</mat-icon>
+                      <span class="ml-2">Add Prescription</span>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </ng-template>
         </div>
       </mat-tab>
+
+      <!-- To Be Dispensed Tab -->
       <mat-tab
         *ngIf="!previous"
-        label="{{
-          drugParams?.useGeneralPrescription === 'true' && !forHistory
-            ? 'To Be Dispensed'
-            : forHistory
-            ? 'Ordered but not dispensed'
-            : 'Doctor\'s Prescriptions'
-        }}"
+        label="{{ drugParams?.useGeneralPrescription === 'true' && !forHistory ? 'To Be Dispensed' : 'Ordered but not dispensed' }}"
       >
         <div class="mat-tab-container">
           <ng-template matTabContent>
             <table class="table">
               <thead>
-                <tr
-                  *ngIf="
-                    drugParams?.filteredDrugOrders?.toBeDispensedDrugOrders
-                      ?.length > 0
-                  "
-                >
+                <tr *ngIf="drugParams?.filteredDrugOrders?.toBeDispensedDrugOrders?.length > 0">
                   <th>SN</th>
                   <th>Drug Details</th>
-                  <th>
-                    {{
-                      drugParams?.useGeneralPrescription === "true"
-                        ? "Verified By"
-                        : "Prescribed By"
-                    }}
-                  </th>
+                  <th>{{ drugParams?.useGeneralPrescription === 'true' ? 'Verified By' : 'Prescribed By' }}</th>
                   <th>Order Date</th>
                 </tr>
               </thead>
               <tbody>
-                <tr
-                  *ngFor="
-                    let drugOrder of drugParams?.filteredDrugOrders
-                      ?.toBeDispensedDrugOrders;
-                    let count = index
-                  "
-                >
+                <tr *ngFor="let drugOrder of drugParams?.filteredDrugOrders?.toBeDispensedDrugOrders; let count = index">
                   <td>{{ count + 1 }}</td>
-                  <td>
-                    {{
-                      drugOrder?.drug
-                        ? drugOrder?.drug?.display
-                        : drugOrder?.drugOrder?.display
-                    }}
-                  </td>
-                  <td>
-                    {{ drugOrder?.orderer?.display }}
-                  </td>
-                  <td>
-                    {{ drugOrder?.dateActivated | date: "medium" }}
+                  <td>{{ drugOrder?.drug ? drugOrder?.drug?.display : drugOrder?.drugOrder?.display }}</td>
+                  <td>{{ drugOrder?.orderer?.display }}</td>
+                  <td>{{ drugOrder?.dateActivated | date: 'medium' }}</td>
+                </tr>
+                <tr *ngIf="drugParams?.filteredDrugOrders?.toBeDispensedDrugOrders?.length === 0" class="text-center p-3">
+                  <td colspan="4">
+                    No {{ drugParams?.useGeneralPrescription === 'true' ? 'drugs to be dispensed' : 'previous prescriptions' }} for this patient
                   </td>
                 </tr>
-                <tr
-                  *ngIf="
-                    drugParams?.filteredDrugOrders?.toBeDispensedDrugOrders
-                      ?.length === 0
-                  "
-                  class="text-center p-3"
-                >
-                  No
-                  {{
-                    drugParams?.useGeneralPrescription === "true"
-                      ? "drugs to be dispensed"
-                      : "previous prescriptions"
-                  }}
-                  for this patient
-                </tr>
-                <tr
-                  *ngIf="
-                    !isInpatient &&
-                    drugParams?.useGeneralPrescription !== 'true'
-                  "
-                >
+                <tr *ngIf="!isInpatient && drugParams?.useGeneralPrescription !== 'true'">
                   <td colspan="4">
                     <button
                       mat-flat-button
@@ -160,15 +104,12 @@
           </ng-template>
         </div>
       </mat-tab>
+
+      <!-- Dispensed Tab -->
       <mat-tab label="Dispensed" *ngIf="!previous">
         <div class="mat-tab-container">
           <ng-template matTabContent>
-            <table
-              class="table table-bordered"
-              *ngIf="
-                drugParams?.filteredDrugOrders?.dispensedDrugOrders?.length > 0
-              "
-            >
+            <table *ngIf="drugParams?.filteredDrugOrders?.dispensedDrugOrders?.length > 0" class="table table-bordered">
               <thead>
                 <tr>
                   <th style="width: 10px">SN</th>
@@ -177,96 +118,63 @@
                 </tr>
               </thead>
               <tbody>
-                <ng-container>
-                  <tr
-                    *ngFor="
-                      let drugOrder of drugParams?.filteredDrugOrders
-                        ?.dispensedDrugOrders;
-                      let count = index
-                    "
-                  >
-                    <td>
-                      {{ count + 1 }}
-                    </td>
-                    <td>
-                      {{
-                        drugOrder?.drug
-                          ? drugOrder?.drug?.display
-                          : drugOrder?.drugOrder?.display
-                      }}
-                    </td>
-                    <td>
-                      {{
-                        drugOrder?.drugOrder?.instructions
-                          ? drugOrder?.drugOrder?.instructions
-                          : drugOrder?.instructions
-                          ? drugOrder?.instructions
-                          : "No instructions written"
-                      }}
-                    </td>
-                  </tr>
-                </ng-container>
-                <ng-container *ngIf="isInpatient && forConsultation">
-                  <tr>
-                    <td colspan="3">
-                      <button
-                        mat-flat-button
-                        class="float-right"
-                        color="primary"
-                        (click)="onAddOrder($event)"
-                      >
-                        <mat-icon>add</mat-icon>
-                        <span class="ml-2">Add Prescription</span>
-                      </button>
-                    </td>
-                  </tr>
-                </ng-container>
+                <tr *ngFor="let drugOrder of drugParams?.filteredDrugOrders?.dispensedDrugOrders; let count = index">
+                  <td>{{ count + 1 }}</td>
+                  <td>{{ drugOrder?.drug ? drugOrder?.drug?.display : drugOrder?.drugOrder?.display }}</td>
+                  <td>{{ drugOrder?.instructions || drugOrder?.drugOrder?.instructions || 'No instructions written' }}</td>
+                </tr>
+                <tr *ngIf="isInpatient && forConsultation">
+                  <td colspan="3">
+                    <button
+                      mat-flat-button
+                      class="float-right"
+                      color="primary"
+                      (click)="onAddOrder($event)"
+                    >
+                      <mat-icon>add</mat-icon>
+                      <span class="ml-2">Add Prescription</span>
+                    </button>
+                  </td>
+                </tr>
               </tbody>
             </table>
-            <table
-              class="table table-striped"
-              *ngIf="
-                drugParams?.filteredDrugOrders?.dispensedDrugOrders?.length ===
-                0
-              "
-            >
+            <table *ngIf="drugParams?.filteredDrugOrders?.dispensedDrugOrders?.length === 0" class="table table-striped">
               <tr class="text-center p-3">
-                No drugs dispensed for this patient
+                <td>No drugs dispensed for this patient</td>
               </tr>
             </table>
           </ng-template>
         </div>
       </mat-tab>
-      <mat-tab
-        label="Stopped Medication"
-        *ngIf="!previous"
-      >
+
+      <!-- Stopped Medication Tab -->
+      <mat-tab label="Stopped Medication" *ngIf="!previous">
         <div class="mat-tab-container">
           <ng-template matTabContent>
-            <div>
-              <table class="w-100 table table-bordered">
-                <thead>
-                  <tr>
-                    <th>S/N</th>
-                    <th>Prescription</th>
-                    <th>Remarks</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr *ngFor="let prescription of prescriptions; let i = index">
-                    <td>{{ i + 1 }}</td>
-                    <td>{{ prescription.name }}</td>
-                    <td>{{ prescription.remarks }}</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div *ngIf="prescriptions.length === 0">
-                No stopped medications available.
-              </div>
+            <table class="w-100 table table-bordered">
+              <thead>
+                <tr>
+                  <th>S/N</th>
+                  <th>Prescription</th>
+                  <th>Remarks</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let prescription of prescriptions; let i = index">
+                  <td>{{ i + 1 }}</td>
+                  <td>{{ prescription.name }}</td>
+                  <td>{{ prescription.remarks }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div *ngIf="prescriptions.length === 0">
+              No stopped medications available.
             </div>
           </ng-template>
         </div>
       </mat-tab>
+
+      <!-- Drugs Tab for Previous Visits -->
       <mat-tab label="Drugs" *ngIf="previous">
         <div class="mat-tab-container">
           <ng-template matTabContent>
@@ -282,73 +190,26 @@
                 </tr>
               </thead>
               <tbody>
-                <ng-container *ngIf="drugParams?.drugOrders?.length > 0"
-                  ><ng-container
-                    *ngFor="
-                      let drugOrder of drugParams?.drugOrders;
-                      let count = index
-                    "
-                  >
-                    <tr *ngIf="drugOrder?.statuses?.length > 0">
-                      <td>
-                        {{ count + 1 }}
-                      </td>
-                      <td>
-                        {{
-                          drugOrder?.drug
-                            ? drugOrder?.drug?.display
-                            : drugOrder?.drugOrder?.display
-                        }}
-                      </td>
-                      <td>
-                        {{
-                          drugOrder?.drugOrder?.instructions
-                            ? drugOrder?.drugOrder?.instructions
-                            : "No instructions written"
-                        }}
-                      </td>
-                      <td>
-                        {{ drugOrder?.orderer?.display }}
-                      </td>
-                      <td>
-                        {{ drugOrder?.dateActivated | date: "medium" }}
-                      </td>
-                      <td>
-                        {{ drugOrder?.dispensed ? "Yes" : "No" }}
-                      </td>
-                    </tr>
-                  </ng-container>
-                </ng-container>
-                <ng-container *ngIf="drugParams?.drugOrders?.length === 0">
-                  <tr>
-                    <td colspan="100%">
-                      No previous visit drugs prescribed for this patient
-                    </td>
-                  </tr>
-                </ng-container>
+                <tr *ngFor="let drugOrder of drugParams?.drugOrders; let count = index">
+                  <td>{{ count + 1 }}</td>
+                  <td>{{ drugOrder?.drug ? drugOrder?.drug?.display : drugOrder?.drugOrder?.display }}</td>
+                  <td>{{ drugOrder?.drugOrder?.instructions || 'No instructions written' }}</td>
+                  <td>{{ drugOrder?.orderer?.display }}</td>
+                  <td>{{ drugOrder?.dateActivated | date: 'medium' }}</td>
+                  <td>{{ drugOrder?.dispensed ? 'Yes' : 'No' }}</td>
+                </tr>
+                <tr *ngIf="drugParams?.drugOrders?.length === 0">
+                  <td colspan="6">No previous visit drugs prescribed for this patient</td>
+                </tr>
               </tbody>
-            </table>
-            <table
-              class="table table-striped"
-              *ngIf="
-                !previous &&
-                drugParams?.filteredDrugOrders?.dispensedDrugOrders?.length ===
-                  0
-              "
-            >
-              <tr class="text-center p-3">
-                No drugs dispensed for this patient
-              </tr>
             </table>
           </ng-template>
         </div>
       </mat-tab>
     </mat-tab-group>
-    <div
-      *ngIf="!drugParams?.currentVisit?.hasConfirmedDiagnosis"
-      class="alert alert-warning"
-      role="alert"
-    >
+
+    <!-- Warning for Missing Diagnosis -->
+    <div *ngIf="!drugParams?.currentVisit?.hasConfirmedDiagnosis" class="alert alert-warning" role="alert">
       NO Confirmed/Final Diagnosis provided. Please provide before Medication
     </div>
   </div>

--- a/ui/src/app/shared/components/prescription/prescription.component.html
+++ b/ui/src/app/shared/components/prescription/prescription.component.html
@@ -31,7 +31,11 @@
         [currentLocation]="params.currentLocation"
         [canAddPrescription]="true"
         (orderSelectAction)="onOrderSelection($event)"
+        (validateActiveDosage)="onValidateActiveDosage($event)"
       ></app-patient-drug-order-list>
+      <div *ngIf="activeDosageConflict" class="alert alert-warning mt-2">
+        A conflicting active dosage exists for the selected medication. Please resolve the conflict before proceeding.
+      </div>
     </div>
   </div>
 </div>

--- a/ui/src/app/shared/components/prescription/prescription.component.scss
+++ b/ui/src/app/shared/components/prescription/prescription.component.scss
@@ -5,3 +5,13 @@
 .add-drug-button {
   float: right;
 }
+
+.active-dosage-warning {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
+  padding: 10px;
+  margin-top: 10px;
+  border-radius: 4px;
+  font-size: 14px;
+}

--- a/ui/src/app/shared/components/prescription/prescription.component.spec.ts
+++ b/ui/src/app/shared/components/prescription/prescription.component.spec.ts
@@ -1,19 +1,30 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { PrescriptionComponent } from './prescription.component';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { AppState } from 'src/app/store/reducers';
 import { storeDataMock } from 'src/test-mocks/store-data.mock';
+import { VisitsService } from 'src/app/shared/resources/visits/services';
+import { DrugOrder } from 'src/app/shared/resources/order/models/drug-order.model';
 
 describe('PrescriptionComponent', () => {
   let component: PrescriptionComponent;
   let fixture: ComponentFixture<PrescriptionComponent>;
 
   let store: MockStore<AppState>;
+  let mockVisitService: jasmine.SpyObj<VisitsService>;
+
   beforeEach(async () => {
+    mockVisitService = jasmine.createSpyObj('VisitsService', ['getActiveVisit']);
+    mockVisitService.getActiveVisit.and.returnValue(of(null));
+
     await TestBed.configureTestingModule({
       declarations: [PrescriptionComponent],
-      providers: [provideMockStore(storeDataMock)],
+      providers: [
+        provideMockStore(storeDataMock),
+        { provide: VisitsService, useValue: mockVisitService },
+      ],
     }).compileComponents();
   });
 
@@ -26,5 +37,24 @@ describe('PrescriptionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should validate active dosage before ordering a drug', () => {
+    spyOn(component, 'onValidateActiveDosage').and.callThrough();
+
+    const mockDrugOrder = new DrugOrder({ id: '123', startDate: new Date(), endDate: null });
+
+    component.onOrderingDrug(mockDrugOrder);
+
+    expect(component.onValidateActiveDosage).toHaveBeenCalledWith(mockDrugOrder);
+  });
+
+  it('should show a warning if active dosage conflict exists', () => {
+    component.activeDosageConflict = true;
+    fixture.detectChanges();
+
+    const warningElement = fixture.nativeElement.querySelector('.active-dosage-warning');
+    expect(warningElement).toBeTruthy();
+    expect(warningElement.textContent).toContain('A conflicting active dosage exists');
   });
 });


### PR DESCRIPTION
The bug occurred because there was no logic in place to check if a patient already had an active prescription with the same dosage before adding a new one, allowing duplicate active prescriptions. This happened due to missing validation in both the component logic and the backend. The solution involved adding a check in the `onAddOrder` method to validate if a similar active prescription exists for the patient and preventing duplication. Additionally, the backend API was updated to enforce this rule server-side for consistency.

Registration Numbers

2022-04-09686
2022-04-07909
2022-04-10338
2022-04-12685
2022-04-01731
Pull Request Link: https://github.com/dhis2-club-tanzania/icare-student/pull/84